### PR TITLE
Overhauls network communication to use C# queues

### DIFF
--- a/Networking/ServerConnection.cs
+++ b/Networking/ServerConnection.cs
@@ -32,16 +32,6 @@ public class ServerConnection : Node
   ReceiverLink securityOutReceiver;
   public static readonly string UUID = System.Guid.NewGuid().ToString();
 
-  // Ugh - seems like we can't seralize protbuf classes via signals so this might not work
-  //[Signal]
-  //public delegate void CreatePlayerGameEvent();
-  //[Signal]
-  //public delegate void CreateMissleGameEvent();
-  //[Signal]
-  //public delegate void UpdatePlayerGameEvent();
-  //[Signal]
-  //public delegate void UpdateMissleGameEvent();
-
   public override void _Ready()
   {
     MyGame = GetNode<Game>("/root/Game");
@@ -282,15 +272,13 @@ public class ServerConnection : Node
           switch (egeb.game_object_type)
           {
             case GameEvent.GameObjectType.GameObjectTypePlayer:
-              _serilogger.Information("ServerConnection.cs: Got create for a ship");
-              PlayerShip newShip = MyGame.CreateShipForUUID(egeb.Uuid);
-              newShip.UpdateFromGameEventBuffer(egeb);
+              _serilogger.Information($"ServerConnection.cs: Got create for a ship {egeb.Uuid}");
+              MyGame.PlayerCreateQueue.Enqueue(egeb);
               break;
 
             case GameEvent.GameObjectType.GameObjectTypeMissile:
-              _serilogger.Information("ServerConnection.cs: Got create for a missile");
-              SpaceMissile newMissile = MyGame.CreateMissileForUUID(egeb);
-              newMissile.UpdateFromGameEventBuffer(egeb);
+              _serilogger.Information($"ServerConnection.cs: Got create for a missile {egeb.Uuid} owner {egeb.OwnerUuid}");
+              MyGame.MissileCreateQueue.Enqueue(egeb);
               break;
           }
           break;
@@ -302,12 +290,12 @@ public class ServerConnection : Node
           {
             case GameEvent.GameObjectType.GameObjectTypePlayer:
               _serilogger.Information($"ServerConnection.cs: Got destroy for player {egeb.Uuid}");
-              MyGame.DestroyShipWithUUID(egeb.Uuid);
+              MyGame.PlayerDestroyQueue.Enqueue(egeb);
               break;
 
             case GameEvent.GameObjectType.GameObjectTypeMissile:
-              _serilogger.Information($"ServerConnection.cs: Got destroy for missile {egeb.Uuid}");
-              MyGame.DestroyMissileWithUUID(egeb.Uuid);
+              _serilogger.Information($"ServerConnection.cs: Got destroy for missile {egeb.Uuid} owner {egeb.OwnerUuid}");
+              MyGame.MissileDestroyQueue.Enqueue(egeb);
               break;
 
           }
@@ -330,15 +318,13 @@ public class ServerConnection : Node
           switch (egeb.game_object_type)
           {
             case GameEvent.GameObjectType.GameObjectTypePlayer:
-              _serilogger.Verbose("ServerConnection.cs: Got update for player");
-              PlayerShip ship = MyGame.UpdateShipWithUUID(egeb.Uuid);
-              ship.UpdateFromGameEventBuffer(egeb);
+              _serilogger.Verbose($"ServerConnection.cs: Got update for player {egeb.Uuid}");
+              MyGame.PlayerUpdateQueue.Enqueue(egeb);
               break;
 
             case GameEvent.GameObjectType.GameObjectTypeMissile:
-              _serilogger.Verbose("ServerConnection.cs: Got update for missile");
-              SpaceMissile missile = MyGame.UpdateMissileWithUUID(egeb);
-              missile.UpdateFromGameEventBuffer(egeb);
+              _serilogger.Verbose($"ServerConnection.cs: Got update for missile {egeb.Uuid} owner {egeb.OwnerUuid}");
+              MyGame.MissileUpdateQueue.Enqueue(egeb);
               break;
           }
           break;

--- a/Scenes/LoginScreen.cs
+++ b/Scenes/LoginScreen.cs
@@ -25,6 +25,7 @@ public class LoginScreen : Control
   private void _on_JoinButton_button_up()
   {
     _serilogger.Information($"LoginScreen: trying to login as {textField.Text}");
+    MyGame.myUuid = textField.Text;
 
     //EmitSignal("SetPlayerName", textField.Text);
     bool success = MyGame.JoinGameAsPlayer(textField.Text);
@@ -35,7 +36,6 @@ public class LoginScreen : Control
     }
     else
     {
-      MyGame.myUuid = textField.Text;
       // since we successfully joined the game, we can remove this node
       // which is the login screen. removing the login screen "displays"
       // the main game window


### PR DESCRIPTION
Instead of immediately performing actions (AddChild, etc) which seemed like it could cause Godot errors, this overhaul implements C# queues to hold messages and then processes them via loops in the main game loop.

There's probably more efficient/better ways to do this, but this is what we've got for now.